### PR TITLE
Dynamically select the path to the configuration directory

### DIFF
--- a/custom_components/simpleicons/__init__.py
+++ b/custom_components/simpleicons/__init__.py
@@ -16,7 +16,6 @@ ICON_FILES = {"simpleicons": "si.js"}
 
 
 class IconView(HomeAssistantView):
-
     requires_auth = False
 
     def __init__(self, slug):
@@ -29,7 +28,6 @@ class IconView(HomeAssistantView):
 
 
 class ListView(HomeAssistantView):
-
     requires_auth = False
 
     def __init__(self):
@@ -41,12 +39,15 @@ class ListView(HomeAssistantView):
 
 
 async def async_setup(hass, config):
-    await hass.http.async_register_static_paths([
-        StaticPathConfig("/simpleicons/si.js",
-                         "/config/custom_components/simpleicons/data/si.js", True
-                         )
-        ])
-
+    await hass.http.async_register_static_paths(
+        [
+            StaticPathConfig(
+                f"/{DOMAIN}/si.js",
+                hass.config.path(f"custom_components/{DOMAIN}/data/si.js"),
+                True,
+            )
+        ]
+    )
 
     hass.http.register_view(ListView())
 


### PR DESCRIPTION
#256 changed from dynamically selecting the path to the configuration directory to hardcoding it to `/config/`. This breaks for users who are not using the docker or Home Assistant OS installation methods. This PR restores the dynamic path computation while still using the newer method of registering a static path.