### PR TITLE
Changes backend library from simpleicons to simplepycons

### DIFF
--- a/custom_components/simpleicons/__init__.py
+++ b/custom_components/simpleicons/__init__.py
@@ -1,11 +1,9 @@
-import homeassistant.components.frontend
-from homeassistant.components.frontend import _frontend_root
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.components.http import StaticPathConfig
+from xml.dom.minidom import Document, parseString
 
-from simpleicons.all import icons
-import json
+from simplepycons import all_icons
 
 DOMAIN = "simpleicons"
 
@@ -14,17 +12,19 @@ ICONS_URL = "/" + DOMAIN + "/"
 ICON_URL = f"/{DOMAIN}/icons"
 ICON_FILES = {"simpleicons": "si.js"}
 
-
 class IconView(HomeAssistantView):
     requires_auth = False
 
     def __init__(self, slug):
         self.url = ICON_URL + "/" + slug
-        self.icon = icons.get(slug)
+        icon = all_icons[slug]
+        dom = parseString(icon.raw_svg)
+        self.path = dom.getElementsByTagName("path")[0].getAttribute("d")
+
         self.name = "Icon View"
 
     async def get(self, request):
-        return self.json({"path": self.icon.path})
+        return self.json({"path": self.path })
 
 
 class ListView(HomeAssistantView):
@@ -35,7 +35,7 @@ class ListView(HomeAssistantView):
         self.name = "Icons View"
 
     async def get(self, request):
-        return self.json([{"name": icon} for icon in icons])
+        return self.json([{"name": icon.prototype.name} for icon in all_icons.__dict__.values()])
 
 
 async def async_setup(hass, config):
@@ -51,8 +51,8 @@ async def async_setup(hass, config):
 
     hass.http.register_view(ListView())
 
-    for icon in icons:
-        hass.http.register_view(IconView(icon))
+    for icon in all_icons.__dict__.values():
+        hass.http.register_view(IconView(icon.prototype.name))
 
     if DOMAIN not in config:
         return True

--- a/custom_components/simpleicons/manifest.json
+++ b/custom_components/simpleicons/manifest.json
@@ -9,7 +9,7 @@
     ],
     "codeowners": [],
     "requirements": [
-        "simpleicons==7.14.0"
+        "simplepycons==1!13.17.0"
     ],
     "config_flow": true,
     "version": "0.0.0"


### PR DESCRIPTION
[simpleicons](https://github.com/sachinraja/simple-icons-py) hasn't been maintained in years and the author is unresponsive 

[simplepycons](https://github.com/carstencodes/simplepycons) is new and follows the latest release

with this PR we can use the latests icons