### PR TITLE
fix: solve 500 internal server error

### DIFF
--- a/custom_components/simpleicons/__init__.py
+++ b/custom_components/simpleicons/__init__.py
@@ -40,7 +40,7 @@ class ListView(HomeAssistantView):
 
     async def get(self, request):
         return self.json(
-            [{"name": icon.prototype.name} for icon in all_icons.__dict__.values()]
+            [{"name": icon} for icon in all_icons.names()]
         )
 
 


### PR DESCRIPTION
icon list did not load anymore, breaking the integration

the error was: `AttributeError: 'dict_keys' object has no attribute 'prototype'`